### PR TITLE
Fix AuthRegistryInterface return type

### DIFF
--- a/src/Onelogin/AuthRegistryInterface.php
+++ b/src/Onelogin/AuthRegistryInterface.php
@@ -10,7 +10,7 @@ use OneLogin\Saml2\Auth;
  */
 interface AuthRegistryInterface
 {
-    public function addService(string $key, Auth $auth): AuthRegistry;
+    public function addService(string $key, Auth $auth): self;
 
     public function hasService(string $key): bool;
 


### PR DESCRIPTION
Like #15, but for 1.0 branch.

The `Nbgrp\OneloginSamlBundle\Onelogin\AuthRegistryInterface::addService` method returns AuthRegistry instead of AuthRegistryInterface: we cannot implement AuthRegistryInterface without Auth class.