### PR TITLE
Allow to override AuthRegistry

### DIFF
--- a/src/DependencyInjection/Compiler/AuthRegistryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AuthRegistryCompilerPass.php
@@ -18,7 +18,7 @@ class AuthRegistryCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        $authRegistry = $container->getDefinition(AuthRegistryInterface::class);
+        $authRegistry = $container->findDefinition(AuthRegistryInterface::class);
 
         $oneloginSettings = $container->getParameter('nbgrp_onelogin_saml.onelogin_settings');
         if (!\is_array($oneloginSettings)) {


### PR DESCRIPTION
This PR allows to change AuthRegistry implementation.

It changes getDefinition to findDefinition in AuthRegistryCompilerPass which allows to search for aliases.