### PR TITLE
fix: logout supports other firewalls without configured AuthService

### DIFF
--- a/src/EventListener/Security/SamlLogoutListener.php
+++ b/src/EventListener/Security/SamlLogoutListener.php
@@ -27,13 +27,13 @@ final readonly class SamlLogoutListener
     #[AsEventListener(LogoutEvent::class)]
     public function processSingleLogout(LogoutEvent $event): void
     {
-        $authService = $this->getAuthService($event->getRequest());
-        if ($authService === null) {
+        $token = $event->getToken();
+        if (!$token instanceof SamlToken) {
             return;
         }
 
-        $token = $event->getToken();
-        if (!$token instanceof SamlToken) {
+        $authService = $this->getAuthService($event->getRequest());
+        if ($authService === null) {
             return;
         }
 

--- a/tests/EventListener/Security/SamlLogoutListenerTest.php
+++ b/tests/EventListener/Security/SamlLogoutListenerTest.php
@@ -130,7 +130,7 @@ final class SamlLogoutListenerTest extends TestCase
             ->willReturn($request)
         ;
         $event
-            ->expects($token ? self::once() : self::never())
+            ->expects(self::once())
             ->method('getToken')
             ->willReturn($token)
         ;


### PR DESCRIPTION
In v1 and v2 of this library, the `SamlLogoutListener` gets first a required `Auth` from the `AuthService` and only after that step checks, if the currently logged in Token is a `SamlToken`. With this setup the SamlBundle will require a valid (saml) `Auth` (config) for all firewall logout requests - even if they do not have anything to do with Saml. 

To fix this problem, I suggest to check first the token and only then get the Auth. This pull request implements the suggested change for v2 of the library. 
If the change is accepted, I can also make a similar PR for the v1 branch.

Note: this PR would also fix Issue #48 